### PR TITLE
fix: correct config parser header comment

### DIFF
--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -1,4 +1,4 @@
-\// File: /var/www/mcaster1.com/DNAS/icy2-server/src/config_parser.cpp
+// File: /var/www/mcaster1.com/DNAS/icy2-server/src/config_parser.cpp
 // Author: davestj@gmail.com (David St. John)
 // Created: 2025-07-16
 // Title: Configuration Parser Implementation - Corrected for Actual Common Types


### PR DESCRIPTION
## Summary
- remove stray leading backslash so the file header comment in `config_parser.cpp` is a valid C++ comment

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68942fae9950832b8152e42b5d1d688a