### PR TITLE
fix: include atomic header in main entry point

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <atomic>
 #include <chrono>
 #include <thread>
 #include <csignal>


### PR DESCRIPTION
## Summary
- include `<atomic>` in `src/main.cpp` so the shutdown flag compiles

## Testing
- `g++ -std=c++17 -Iinclude -pthread -c src/main.cpp -o /tmp/main.o -v`


------
https://chatgpt.com/codex/tasks/task_e_68942fb0c350832ba2c819039d58de14