### PR TITLE
feat: add HTTP listener connection type

### DIFF
--- a/include/common_types.h
+++ b/include/common_types.h
@@ -89,6 +89,7 @@ enum class ConnectionType {
     HTTPS,          // I identify HTTPS connections
     ICY_SOURCE,     // I identify ICY source broadcasting connections
     ICY_LISTENER,   // I identify ICY listener connections
+    HTTP_LISTENER,  // I identify standard HTTP listener connections
     PHP_FPM,        // I identify PHP-FPM FastCGI connections
     API,            // I identify REST API connections
     WEBSOCKET,      // I identify WebSocket connections


### PR DESCRIPTION
## Summary
- add `HTTP_LISTENER` to `ConnectionType` for standard HTTP listener connections

## Testing
- `./bootstrap.sh` *(fails: cannot find PHP version)*
- `./autogen.sh` *(fails: possibly undefined macro AC_MSG_ERROR)*
- `g++ -std=c++17 -Iinclude -c src/*.cpp` *(fails: base64_encode not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68944d1c2b98832bab3eba07e8a399b3