### PR TITLE
fix: declare connection handlers

### DIFF
--- a/include/server.h
+++ b/include/server.h
@@ -244,10 +244,13 @@ private:
     bool initialize_sockets();
     bool bind_and_listen(int& socket_fd, uint16_t port, bool ssl);
     void accept_connections();
+    void accept_new_connection(int listening_socket, bool is_ssl, bool is_admin);
     void worker_thread_main();
     void handle_connection(std::unique_ptr<ClientConnection> conn);
     void process_http_request(ClientConnection* conn);
+    void handle_status_request(ClientConnection* conn);
     void process_api_request(ClientConnection* conn);
+    void handle_api_status_request(ClientConnection* conn);
     void process_icy_request(ClientConnection* conn);
     void process_php_request(ClientConnection* conn);
     void send_http_response(ClientConnection* conn, int status_code,
@@ -261,5 +264,4 @@ private:
 };
 
 } // namespace icy2
-
 #endif // ICY2_SERVER_H


### PR DESCRIPTION
## Summary
- declare private methods `accept_new_connection`, `handle_status_request`, and `handle_api_status_request` in ICY2Server

## Testing
- `./autogen.sh`
- `./configure --prefix=/usr/local`
- `make -j5` *(fails: HTTP_LISTENER not a member of ConnectionType, missing base64/hmac symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68944d171320832bb45c2079bc78bcc9