### PR TITLE
Add cryptographic helpers for AuthTokenManager

### DIFF
--- a/include/auth_token.h
+++ b/include/auth_token.h
@@ -265,6 +265,9 @@ private:
     bool validate_username(const std::string& username);   // I validate username format
     bool validate_password_strength(const std::string& password); // I check password strength
     std::string get_geolocation(const std::string& ip);    // I get IP geolocation
+    std::string base64_encode(const std::string& input);   // I base64 encode data
+    std::string base64_decode(const std::string& input);   // I base64 decode data
+    std::string hmac_sha256(const std::string& data, const std::string& key); // I compute HMAC-SHA256
 
 public:
     /**


### PR DESCRIPTION
## Summary
- declare base64 and HMAC helper functions in AuthTokenManager
- implement full base64 decoding to support JWT parsing

## Testing
- `g++ -std=c++17 -c src/auth_token.cpp -Iinclude` *(fails: binding reference of type 'std::mutex&' to 'const std::mutex')*

------
https://chatgpt.com/codex/tasks/task_e_68954d8481c4832ba0ec8fc871a4c616