### PR TITLE
Mark mutexes mutable for const access

### DIFF
--- a/include/auth_token.h
+++ b/include/auth_token.h
@@ -222,15 +222,15 @@ private:
     std::unordered_map<std::string, UserAccount> users_;    // I store user accounts
     std::unordered_map<std::string, UserSession> sessions_; // I manage active sessions
     std::unordered_map<std::string, APIKey> api_keys_;      // I store API keys
-    std::mutex users_mutex_;                                // I protect user data
+    mutable std::mutex users_mutex_;                        // I protect user data
     std::mutex sessions_mutex_;                             // I protect session data
     std::mutex api_keys_mutex_;                             // I protect API key data
 
     // I'm defining authentication tracking
     std::vector<AuthAttempt> auth_attempts_;                // I track auth attempts
     std::vector<SecurityEvent> security_events_;            // I log security events
-    std::mutex auth_attempts_mutex_;                        // I protect attempt data
-    std::mutex security_events_mutex_;                      // I protect event data
+    mutable std::mutex auth_attempts_mutex_;                // I protect attempt data
+    mutable std::mutex security_events_mutex_;              // I protect event data
 
     // I'm defining configuration
     std::string jwt_secret_;                                // I store JWT signing secret
@@ -245,7 +245,7 @@ private:
     std::unordered_map<std::string, std::vector<std::chrono::steady_clock::time_point>> rate_limits_; // I track IP rates
     std::unordered_map<std::string, int> failed_attempts_; // I count failed attempts per IP
     std::unordered_map<std::string, std::chrono::steady_clock::time_point> lockouts_; // I track IP lockouts
-    std::mutex rate_limit_mutex_;                           // I protect rate limit data
+    mutable std::mutex rate_limit_mutex_;                   // I protect rate limit data
 
     // I'm defining helper methods
     std::string generate_session_id();                      // I create unique session IDs

--- a/include/php_handler.h
+++ b/include/php_handler.h
@@ -237,7 +237,7 @@ private:
 
     // I'm defining statistics and monitoring
     PHPHandlerStats stats_;                             // I track handler statistics
-    std::mutex stats_mutex_;                            // I protect statistics data
+    mutable std::mutex stats_mutex_;                    // I protect statistics data
 
     // I'm defining helper methods
     bool connect_to_pool(const std::string& pool_name, FastCGIConnection& conn); // I connect to PHP-FPM

--- a/include/ssl_manager.h
+++ b/include/ssl_manager.h
@@ -198,7 +198,7 @@ private:
     // I'm defining certificate storage and tracking
     std::map<std::string, CertificateInfo> certificates_; // I store certificate information
     std::map<std::string, CertificateMonitoring> monitoring_; // I track certificate monitoring
-    std::mutex certificates_mutex_;         // I protect certificate data
+    mutable std::mutex certificates_mutex_; // I protect certificate data
     std::mutex monitoring_mutex_;           // I protect monitoring data
 
     // I'm defining certificate validation and caching


### PR DESCRIPTION
## Summary
- allow const AuthTokenManager access to user and security data by marking related mutexes mutable
- make SSL and PHP handler mutexes mutable to support locking in const methods

## Testing
- `./configure`
- `make -j$(nproc)` *(fails: base64_encode/hmac_sha256 undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68954d86e3e8832bb8793cb57d75f480