### PR TITLE
fix: include iomanip for ssl_manager

### DIFF
--- a/src/ssl_manager.cpp
+++ b/src/ssl_manager.cpp
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <iomanip>
 #include <algorithm>
 #include <ctime>
 #include <sys/stat.h>


### PR DESCRIPTION
## Summary
- include `<iomanip>` in `ssl_manager.cpp` so `std::setw` and `std::setfill` compile

## Testing
- `g++ -std=c++17 -Iinclude -c src/ssl_manager.cpp` *(fails: aggregate ‘sockaddr_in sa’ has incomplete type)*

------
https://chatgpt.com/codex/tasks/task_e_6895534908ec832ba04169a01c47c1be