### PR TITLE
fix: include IPv4 network headers

### DIFF
--- a/src/ssl_manager.cpp
+++ b/src/ssl_manager.cpp
@@ -31,6 +31,8 @@
 #include <algorithm>
 #include <ctime>
 #include <sys/stat.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <unistd.h>
 
 namespace icy2 {


### PR DESCRIPTION
## Summary
- include `<netinet/in.h>` and `<arpa/inet.h>` in `ssl_manager.cpp` for IPv4 structures and functions

## Testing
- `g++ -std=c++17 -c src/ssl_manager.cpp -Iinclude` *(fails: cannot convert 'const ASN1_OBJECT**' to 'const X509_ALGOR**'; `'setw'` is not a member of `std`)*

------
https://chatgpt.com/codex/tasks/task_e_6895533d7e00832b94a1b3b4299a9e24