### PR TITLE
feat: make SSL optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,11 +64,18 @@ AX_PTHREAD([
 ])
 
 # I'm checking for required libraries (all passed in your test)
+if test "x$enable_ssl" = "xyes"; then
 PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.1.0], [
     AC_DEFINE([HAVE_OPENSSL], [1], [Define if OpenSSL is available])
 ], [
     AC_MSG_ERROR([I require OpenSSL 1.1.0+. Install: apt-get install libssl-dev])
 ])
+else
+    OPENSSL_LIBS=""
+    OPENSSL_CFLAGS=""
+fi
+AC_SUBST([OPENSSL_LIBS])
+AC_SUBST([OPENSSL_CFLAGS])
 
 PKG_CHECK_MODULES([YAML_CPP], [yaml-cpp >= 0.6.0], [
     AC_DEFINE([HAVE_YAML_CPP], [1], [Define if yaml-cpp is available])
@@ -102,7 +109,7 @@ AC_ARG_ENABLE([debug],
 
 AC_ARG_ENABLE([ssl],
     AS_HELP_STRING([--enable-ssl], [Enable SSL support]),
-    [enable_ssl=$enableval], [enable_ssl=yes])
+    [enable_ssl=$enableval], [enable_ssl=no])
 
 AC_ARG_ENABLE([php-fmp],
     AS_HELP_STRING([--enable-php-fmp], [Enable PHP-FPM support]),

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,9 +54,12 @@ icy2_server_SOURCES = \
     icy_handler.cpp \
     config_parser.cpp \
     auth_token.cpp \
-    ssl_manager.cpp \
     php_handler.cpp \
     helper.cpp
+
+if SSL
+icy2_server_SOURCES += ssl_manager.cpp
+endif
 
 # I'm defining header dependencies for proper rebuilding
 noinst_HEADERS = \
@@ -69,7 +72,10 @@ noinst_HEADERS = \
     $(top_srcdir)/include/helper.h
 
 # I'm defining external library dependencies
-icy2_server_LDADD = $(OPENSSL_LIBS) $(YAML_CPP_LIBS) -lfcgi -lpthread -ldl
+icy2_server_LDADD = $(YAML_CPP_LIBS) -lfcgi -lpthread -ldl
+if SSL
+icy2_server_LDADD += $(OPENSSL_LIBS)
+endif
 
 # I'm setting up library installation
 lib_LIBRARIES = libicy2-server.a
@@ -83,9 +89,12 @@ libicy2_server_a_SOURCES = \
     icy_handler.cpp \
     config_parser.cpp \
     auth_token.cpp \
-    ssl_manager.cpp \
     php_handler.cpp \
     helper.cpp
+
+if SSL
+libicy2_server_a_SOURCES += ssl_manager.cpp
+endif
 
 # I'm setting library-specific compiler flags
 libicy2_server_a_CXXFLAGS = $(AM_CXXFLAGS) -fPIC
@@ -95,7 +104,10 @@ if SHARED_LIBS
 libicy2_server_la_SOURCES = $(libicy2_server_a_SOURCES)
 libicy2_server_la_CXXFLAGS = $(AM_CXXFLAGS) -fPIC
 libicy2_server_la_LDFLAGS = -version-info 1:1:0 -shared
-libicy2_server_la_LIBADD = $(OPENSSL_LIBS) $(YAML_CPP_LIBS) -lfcgi -lpthread -ldl
+libicy2_server_la_LIBADD = $(YAML_CPP_LIBS) -lfcgi -lpthread -ldl
+if SSL
+libicy2_server_la_LIBADD += $(OPENSSL_LIBS)
+endif
 endif
 
 # I'm defining header installation for the public API


### PR DESCRIPTION
## Summary
- default SSL support to disabled
- only check for and link OpenSSL when SSL is enabled
- gate ssl_manager sources and OpenSSL libs behind SSL build option

## Testing
- `autoreconf -fi` *(fails: possibly undefined macro: AC_MSG_ERROR)*
- `./configure` *(fails: cannot find required auxiliary files: config.guess config.sub ar-lib compile missing install-sh)*

------
https://chatgpt.com/codex/tasks/task_e_6895533a0e98832bbb996b44d94110d2