### PR TITLE
fix: call member shutdown in PHPHandler destructor

### DIFF
--- a/src/php_handler.cpp
+++ b/src/php_handler.cpp
@@ -77,7 +77,7 @@ PHPHandler::PHPHandler(const std::string& socket_path, const std::string& docume
  * This ensures proper cleanup of resources and connections
  */
 PHPHandler::~PHPHandler() {
-    shutdown();
+    this->shutdown();
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure `PHPHandler` destructor invokes its own `shutdown` member by using `this->` qualifier

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68955c3f0c2c832ba117f242f04d8b13