### PR TITLE
Include atomic for PHP handler

### DIFF
--- a/include/php_handler.h
+++ b/include/php_handler.h
@@ -33,6 +33,7 @@
 #include <unordered_map>
 #include <memory>
 #include <mutex>
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <fcgiapp.h>


### PR DESCRIPTION
## Summary
- include `<atomic>` in php handler header to provide definition for `std::atomic`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68955c285bb0832b9ed57969121efdbc