### PR TITLE
fix: include thread header in PHP handler

### DIFF
--- a/src/php_handler.cpp
+++ b/src/php_handler.cpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <thread>
 
 namespace icy2 {
 


### PR DESCRIPTION
## Summary
- include `<thread>` in `src/php_handler.cpp` so threading utilities compile

## Testing
- `g++ -std=c++17 -pthread -Iinclude -c src/php_handler.cpp -o /tmp/php_handler.o` *(fails: fcgiapp.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68955ce847bc832b975f48c42716c119