### PR TITLE
Add YAML configuration script and Makefile target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,8 @@ EXTRA_DIST = \
     LICENSE.md \
     bootstrap.sh \
     autogen.sh \
-    config/mcaster1.yaml
+    config/mcaster1.yaml \
+    scripts/configure_yaml.sh
 
 # I'm defining custom cleaning targets with different levels of thoroughness
 # These targets provide users with multiple options for resetting their build environment
@@ -128,6 +129,10 @@ test-config:
 	@echo "I'm testing the configuration..."
 	./src/icy2-server --test-mode
 
+# I'm adding a configuration helper target
+config:
+	bash scripts/configure_yaml.sh
+
 # Development setup target that includes cleanup and regeneration
 dev-reset: bootstrap-clean
 	@echo "I'm performing complete development environment reset..."
@@ -165,4 +170,4 @@ clean-help:
 	@echo "  make dev-reset                        # Reset and configure for development"
 	@echo "  make clean && make                    # Quick rebuild"
 
-.PHONY: lib install-lib generate-ssl test-config dev-reset clean-help
+.PHONY: lib install-lib generate-ssl test-config dev-reset clean-help config

--- a/scripts/configure_yaml.sh
+++ b/scripts/configure_yaml.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+# Prompt for configuration values
+read -p "Listen IP: " listen_ip
+read -p "Port: " port
+read -p "Admin username: " admin_user
+read -s -p "Admin password: " admin_pass
+echo
+read -p "Output filename [server.yaml]: " out_file
+out_file=${out_file:-server.yaml}
+
+# Ensure config directory exists
+mkdir -p config
+
+# Write configuration to YAML file
+cat > "config/${out_file}" <<YAML
+server:
+  listen_ip: "${listen_ip}"
+  port: ${port}
+admin:
+  username: "${admin_user}"
+  password: "${admin_pass}"
+YAML
+
+echo "Configuration written to config/${out_file}"


### PR DESCRIPTION
## Summary
- add interactive `configure_yaml.sh` script to generate server YAML config files
- hook script into build with new `config` target in `Makefile.am`

## Testing
- `./autogen.sh`
- `PKG_CONFIG=/usr/bin/pkg-config ./configure`
- `make config`

------
https://chatgpt.com/codex/tasks/task_e_68955c5f0980832bb0469b00bc8274b2