### PR TITLE
fix: replace PHPConfiguration with PHPConfig

### DIFF
--- a/include/php_handler.h
+++ b/include/php_handler.h
@@ -36,6 +36,7 @@
 #include <chrono>
 #include <functional>
 #include <fcgiapp.h>
+#include "common_types.h"
 
 namespace icy2 {
 
@@ -262,7 +263,8 @@ public:
     /**
      * I'm creating the constructor to initialize the PHP handler
      */
-    PHPHandler();
+    PHPHandler(const std::string& socket_path, const std::string& document_root,
+               const PHPConfig& config);
 
     /**
      * I'm creating the destructor to clean up resources

--- a/src/php_handler.cpp
+++ b/src/php_handler.cpp
@@ -42,8 +42,8 @@ namespace icy2 {
  * I'm implementing the PHP handler constructor
  * This initializes my PHP-FMP integration with proper configuration
  */
-PHPHandler::PHPHandler(const std::string& socket_path, const std::string& document_root, 
-                       const PHPConfiguration& config)
+PHPHandler::PHPHandler(const std::string& socket_path, const std::string& document_root,
+                       const PHPConfig& config)
     : socket_path_(socket_path)
     , document_root_(document_root)
     , config_(config)


### PR DESCRIPTION
## Summary
- use existing PHPConfig type instead of undefined PHPConfiguration
- include common_types.h in php_handler header and update constructor signature

## Testing
- `g++ -std=c++17 -Iinclude -c src/php_handler.cpp` *(fails: class `PHPHandler` missing fields; compile attempted)*

------
https://chatgpt.com/codex/tasks/task_e_68955c35c6a8832ba3e516ee373b77c0