### PR TITLE
refactor: replace PHPPoolConfig with PHPConfig

### DIFF
--- a/include/php_handler.h
+++ b/include/php_handler.h
@@ -132,7 +132,7 @@ public:
      * @param config Pool configuration
      * @return true if pool was added successfully
      */
-    bool add_pool(const std::string& pool_name, const PHPPoolConfig& config);
+    bool add_pool(const std::string& pool_name, const PHPConfig& config);
 
     /**
      * I'm creating the method to remove a PHP-FPM pool

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -197,16 +197,8 @@ bool ICY2Server::initialize(const std::string& config_path) {
                 return false;
             }
 
-            // FIXED: I add a default PHP-FPM pool with correct two-argument signature
-            PHPPoolConfig pool_config;
-            pool_config.pool_name = "default";
-            pool_config.socket_path = server_config.php_fmp.socket_path;
-            pool_config.document_root = server_config.php_fmp.document_root;
-            pool_config.index_files = server_config.php_fmp.index_files;
-            pool_config.connection_timeout_ms = server_config.php_fmp.timeout_seconds * 1000;
-            pool_config.request_timeout_ms = server_config.php_fmp.timeout_seconds * 1000;
-
-            if (!php_handler_->add_pool("default", pool_config)) {
+            // I add a default PHP-FPM pool using the parsed PHP configuration
+            if (!php_handler_->add_pool("default", server_config.php_fmp)) {
                 std::cerr << "I failed to add PHP-FPM pool" << std::endl;
                 return false;
             }


### PR DESCRIPTION
## Summary
- simplify PHP pool configuration by accepting PHPConfig directly
- adjust server initialization to pass PHPConfig when registering default pool

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6895638a8448832b9dfce53371f3a95a