### PR TITLE
refactor: rely on constructor for PHP handler

### DIFF
--- a/include/php_handler.h
+++ b/include/php_handler.h
@@ -108,29 +108,6 @@ public:
      */
     virtual ~PHPHandler();
 
-    /**
-     * I'm creating the method to configure the PHP handler
-     * @param config PHP-FPM configuration settings
-     * @return true if configuration succeeded
-     */
-    bool configure(const PHPConfig& config);
-
-    /**
-     * I'm creating the method to add a PHP-FPM pool
-     * @param pool_name Unique pool identifier
-     * @param config Pool configuration
-     * @return true if pool was added successfully
-     */
-    bool add_pool(const std::string& pool_name, const PHPConfig& config);
-
-    /**
-     * I'm creating the method to remove a PHP-FPM pool
-     * @param pool_name Pool identifier to remove
-     * @return true if pool was removed successfully
-     */
-    bool remove_pool(const std::string& pool_name);
-
-
     bool initialize();
     void shutdown();
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -183,18 +183,15 @@ bool ICY2Server::initialize(const std::string& config_path) {
             }
         }
 
-        // I create and configure the PHP handler if enabled
+        // I create and initialize the PHP handler if enabled
         if (server_config.php_fmp.enabled) {
-            php_handler_ = std::make_unique<PHPHandler>();
+            php_handler_ = std::make_unique<PHPHandler>(
+                server_config.php_fmp.socket_path,
+                server_config.php_fmp.document_root,
+                server_config.php_fmp);
 
-            if (!php_handler_->configure(server_config.php_fmp)) {
+            if (!php_handler_->initialize()) {
                 std::cerr << "I failed to initialize PHP handler" << std::endl;
-                return false;
-            }
-
-            // I add a default PHP-FPM pool using the parsed PHP configuration
-            if (!php_handler_->add_pool("default", server_config.php_fmp)) {
-                std::cerr << "I failed to add PHP-FPM pool" << std::endl;
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- streamline PHPHandler API by dropping unused configure and pool management methods
- initialize PHPHandler directly in server setup using constructor parameters

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_6895676406d4832b8ece88f593f8ee29