### PR TITLE
refactor: construct PHP handler with config

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -183,18 +183,15 @@ bool ICY2Server::initialize(const std::string& config_path) {
             }
         }
 
-        // I create and configure the PHP handler if enabled
-        if (server_config.php_fmp.enabled) {
-            php_handler_ = std::make_unique<PHPHandler>();
+        // I create and initialize the PHP handler if enabled
+        if (server_config.php_fpm.enabled) {
+            php_handler_ = std::make_unique<PHPHandler>(
+                server_config.php_fpm.socket_path,
+                server_config.php_fpm.document_root,
+                server_config.php_fpm);
 
-            if (!php_handler_->configure(server_config.php_fmp)) {
+            if (!php_handler_->initialize()) {
                 std::cerr << "I failed to initialize PHP handler" << std::endl;
-                return false;
-            }
-
-            // I add a default PHP-FPM pool using the parsed PHP configuration
-            if (!php_handler_->add_pool("default", server_config.php_fmp)) {
-                std::cerr << "I failed to add PHP-FPM pool" << std::endl;
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- create PHPHandler with socket path, document root, and config directly from `server_config.php_fpm`
- drop separate `configure` and `add_pool` calls and initialize the handler immediately

## Testing
- `g++ -std=c++17 -c src/server.cpp -Iinclude -o /tmp/server.o` *(fails: yaml-cpp/yaml.h: No such file or directory)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6895678430e0832bafb2b68382b527cd