### PR TITLE
fix: close active connections directly

### DIFF
--- a/src/php_handler.cpp
+++ b/src/php_handler.cpp
@@ -141,7 +141,7 @@ void PHPHandler::shutdown() {
         if (elapsed > std::chrono::seconds(30)) {
             // I force close remaining connections after timeout
             for (auto& conn : active_connections_) {
-                close_connection(conn.get());
+                close_connection(conn);
             }
             break;
         }


### PR DESCRIPTION
## Summary
- Close active connections using the raw pointer in `shutdown()`

## Testing
- `g++ -std=c++17 -Iinclude -c src/php_handler.cpp` *(fails: ‘test_php_fpm_connection’ not declared)*

------
https://chatgpt.com/codex/tasks/task_e_689567894964832bb4f9dd38a4e27422