### PR TITLE
refactor: initialize PHPHandler with php-fpm config

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -184,11 +184,11 @@ bool ICY2Server::initialize(const std::string& config_path) {
         }
 
         // I create and initialize the PHP handler if enabled
-        if (server_config.php_fmp.enabled) {
+        if (server_config.php_fpm.enabled) {
             php_handler_ = std::make_unique<PHPHandler>(
-                server_config.php_fmp.socket_path,
-                server_config.php_fmp.document_root,
-                server_config.php_fmp);
+                server_config.php_fpm.socket_path,
+                server_config.php_fpm.document_root,
+                server_config.php_fpm);
 
             if (!php_handler_->initialize()) {
                 std::cerr << "I failed to initialize PHP handler" << std::endl;


### PR DESCRIPTION
## Summary
- initialize PHP handler directly with php-fpm configuration

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6895691467dc832bbed2bdc4582568a1