### PR TITLE
Rename php_fmp references to php_fpm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -139,7 +139,7 @@ dev-reset: bootstrap-clean
 	@echo "Regenerating autotools build system..."
 	./autogen.sh
 	@echo "Configuring with development options..."
-	./configure --enable-debug --enable-ssl --enable-php-fmp
+    ./configure --enable-debug --enable-ssl --enable-php-fpm
 	@echo "Development environment reset complete."
 
 # I'm adding a help target that explains all the cleaning options

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -535,8 +535,8 @@ AC_ARG_ENABLE([ssl],
 AM_CONDITIONAL([SSL], [test "x$ssl" = "xyes"])
 
 AC_ARG_ENABLE([php-fpm],
-    AS_HELP_STRING([--enable-php-fmp], [Enable PHP-FPM support]),
-    [php_fpm=$enableval], [php_fmp=yes])
+    AS_HELP_STRING([--enable-php-fpm], [Enable PHP-FPM support]),
+    [php_fpm=$enableval], [php_fpm=yes])
 
 AM_CONDITIONAL([PHP_FPM], [test "x$php_fpm" = "xyes"])
 
@@ -553,7 +553,7 @@ ICY2-SERVER Configuration Summary:
   Version:      ${VERSION}
   Debug build:  ${debug}
   SSL support:  ${ssl}
-  PHP-FPM:      ${php_fmp}
+  PHP-FPM:      ${php_fpm}
   
   CC:           ${CC}
   CXX:          ${CXX}

--- a/configure.ac
+++ b/configure.ac
@@ -111,9 +111,9 @@ AC_ARG_ENABLE([ssl],
     AS_HELP_STRING([--enable-ssl], [Enable SSL support]),
     [enable_ssl=$enableval], [enable_ssl=no])
 
-AC_ARG_ENABLE([php-fmp],
-    AS_HELP_STRING([--enable-php-fmp], [Enable PHP-FPM support]),
-    [enable_php_fmp=$enableval], [enable_php_fmp=yes])
+AC_ARG_ENABLE([php-fpm],
+    AS_HELP_STRING([--enable-php-fpm], [Enable PHP-FPM support]),
+    [enable_php_fpm=$enableval], [enable_php_fpm=yes])
 
 AC_ARG_ENABLE([shared],
     AS_HELP_STRING([--enable-shared], [Build shared libraries]),
@@ -122,8 +122,8 @@ AC_ARG_ENABLE([shared],
 # I'm defining ALL the conditionals that src/Makefile.am actually uses
 # This fixes the "does not appear in AM_CONDITIONAL" errors
 
-# I'm fixing the PHP_FMP conditional (this was the main error)
-AM_CONDITIONAL([PHP_FMP], [test "x$enable_php_fmp" = "xyes"])
+# I'm fixing the PHP_FPM conditional (this was the main error)
+AM_CONDITIONAL([PHP_FPM], [test "x$enable_php_fpm" = "xyes"])
 
 # I'm defining the other conditionals that src/Makefile.am references
 AM_CONDITIONAL([DEBUG], [test "x$enable_debug" = "xyes"])
@@ -157,7 +157,7 @@ if test "x$enable_ssl" = "xyes"; then
     AC_DEFINE([ICY2_SSL_ENABLED], [1], [Define if SSL support is enabled])
 fi
 
-if test "x$enable_php_fmp" = "xyes"; then
+if test "x$enable_php_fpm" = "xyes"; then
     AC_DEFINE([ICY2_PHP_ENABLED], [1], [Define if PHP-FPM support is enabled])
 fi
 
@@ -195,7 +195,7 @@ echo "=================================="
 echo "Version:           $PACKAGE_VERSION"
 echo "Debug build:       $enable_debug"
 echo "SSL support:       $enable_ssl"
-echo "PHP-FPM support:   $enable_php_fmp"
+echo "PHP-FPM support:   $enable_php_fpm"
 echo "Shared libraries:  $enable_shared_libs"
 echo "Platform:          $host_os"
 echo ""

--- a/include/common_types.h
+++ b/include/common_types.h
@@ -437,7 +437,7 @@ struct ServerConfig {
     ICYProtocolConfig icy_protocol;
     LoggingConfig logging;
     YPDirectoryConfig yp_directories;
-    PHPConfig php_fmp;
+    PHPConfig php_fpm;
     APIConfig api;
     PerformanceConfig performance;
     DevelopmentConfig development;

--- a/include/php_handler.h
+++ b/include/php_handler.h
@@ -140,7 +140,7 @@ private:
     std::string method_to_string(PHPRequestType method);
     bool validate_request(const std::string& uri,
                           const std::unordered_map<std::string, std::string>& headers);
-    bool test_php_fmp_connection();
+    bool test_php_fpm_connection();
     void setup_environment_template();
     void close_connection(FastCGIConnection* connection);
     void record_successful_request(std::chrono::steady_clock::time_point start_time);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,7 +40,7 @@ AM_CPPFLAGS += -DICY2_SSL_ENABLED
 endif
 
 # I'm adding PHP-FPM support flags when enabled
-if PHP_FMP
+if PHP_FPM
 AM_CPPFLAGS += -DICY2_PHP_ENABLED
 endif
 

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -136,7 +136,7 @@ bool ConfigParser::load_config(const std::string& file_path) {
 
         // I parse PHP configuration using actual PHPConfig members
         if (root["php"]) {
-            parse_success &= parse_php_config(root["php"], new_config->php_fmp);
+            parse_success &= parse_php_config(root["php"], new_config->php_fpm);
         }
 
         // I parse API configuration using actual APIConfig members

--- a/src/php_handler.cpp
+++ b/src/php_handler.cpp
@@ -3,11 +3,11 @@
  * Path: /var/www/mcaster1.com/DNAS/icy2-server/src/php_handler.cpp
  * Author: davestj@gmail.com (David St. John)
  * Created: 2025-07-16
- * Purpose: I created this PHP-FMP FastCGI handler implementation to provide seamless
+ * Purpose: I created this PHP-FPM FastCGI handler implementation to provide seamless
  *          PHP integration that mimics nginx's php-fpm functionality for web admin
  *          interfaces and dynamic content generation in ICY2-SERVER.
  * 
- * Reason: I need robust PHP-FMP integration to support modern web-based administration,
+ * Reason: I need robust PHP-FPM integration to support modern web-based administration,
  *         dynamic configuration management, and interactive dashboards while maintaining
  *         the performance and security standards of the core streaming server.
  *
@@ -19,9 +19,9 @@
  * 2025-07-16 - Integrated timeout handling and resource management
  *
  * Next Dev Feature: I plan to add PHP session clustering and advanced caching mechanisms
- * Git Commit: feat: implement complete PHP-FMP FastCGI integration with nginx-style processing
+ * Git Commit: feat: implement complete PHP-FPM FastCGI integration with nginx-style processing
  *
- * TODO: Add session replication, response caching, load balancing across PHP-FMP pools
+ * TODO: Add session replication, response caching, load balancing across PHP-FPM pools
  */
 
 #include "php_handler.h"
@@ -41,7 +41,7 @@ namespace icy2 {
 
 /**
  * I'm implementing the PHP handler constructor
- * This initializes my PHP-FMP integration with proper configuration
+ * This initializes my PHP-FPM integration with proper configuration
  */
 PHPHandler::PHPHandler(const std::string& socket_path, const std::string& document_root,
                        const PHPConfig& config)
@@ -83,7 +83,7 @@ PHPHandler::~PHPHandler() {
 
 /**
  * I'm implementing the initialization function
- * This sets up my PHP-FMP connection pool and validates configuration
+ * This sets up my PHP-FPM connection pool and validates configuration
  */
 bool PHPHandler::initialize() {
     std::lock_guard<std::mutex> lock(connection_mutex_);
@@ -92,9 +92,9 @@ bool PHPHandler::initialize() {
         return true;
     }
     
-    // I test the PHP-FMP socket connectivity
+    // I test the PHP-FPM socket connectivity
     if (!test_php_fpm_connection()) {
-        last_error_ = "Cannot connect to PHP-FMP socket: " + socket_path_;
+        last_error_ = "Cannot connect to PHP-FPM socket: " + socket_path_;
         return false;
     }
     
@@ -194,7 +194,7 @@ bool PHPHandler::handle_http_request(PHPRequestType method, const std::string& u
         if (!connection) {
             response.status = PHPResponseStatus::CONNECTION_FAILED;
             response.http_status_code = 503;
-            response.error_message = "No available PHP-FMP connections";
+            response.error_message = "No available PHP-FPM connections";
             record_failed_request(request_start);
             return false;
         }
@@ -244,7 +244,7 @@ bool PHPHandler::process_fastcgi_request(FastCGIConnection* connection,
     // I ensure the connection is active
     if (!ensure_connection_active(connection)) {
         response.status = PHPResponseStatus::CONNECTION_FAILED;
-        response.error_message = "Failed to establish PHP-FMP connection";
+        response.error_message = "Failed to establish PHP-FPM connection";
         return false;
     }
     
@@ -533,7 +533,7 @@ bool PHPHandler::is_connection_valid(FastCGIConnection* connection) {
 
 /**
  * I'm implementing connection establishment
- * This creates actual socket connections to PHP-FMP
+ * This creates actual socket connections to PHP-FPM
  */
 bool PHPHandler::ensure_connection_active(FastCGIConnection* connection) {
     if (connection->is_connected && connection->socket_fd >= 0) {
@@ -556,7 +556,7 @@ bool PHPHandler::ensure_connection_active(FastCGIConnection* connection) {
     addr.sun_family = AF_UNIX;
     strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
     
-    // I connect to PHP-FMP socket
+    // I connect to PHP-FPM socket
     if (connect(connection->socket_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         if (errno != EINPROGRESS) {
             close(connection->socket_fd);
@@ -626,7 +626,7 @@ bool PHPHandler::validate_request(const std::string& uri,
     return true;
 }
 
-bool PHPHandler::test_php_fmp_connection() {
+bool PHPHandler::test_php_fpm_connection() {
     int test_socket = socket(AF_UNIX, SOCK_STREAM, 0);
     if (test_socket < 0) {
         return false;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -184,11 +184,11 @@ bool ICY2Server::initialize(const std::string& config_path) {
         }
 
         // I create and initialize the PHP handler if enabled
-        if (server_config.php_fmp.enabled) {
+        if (server_config.php_fpm.enabled) {
             php_handler_ = std::make_unique<PHPHandler>(
-                server_config.php_fmp.socket_path,
-                server_config.php_fmp.document_root,
-                server_config.php_fmp);
+                server_config.php_fpm.socket_path,
+                server_config.php_fpm.document_root,
+                server_config.php_fpm);
 
             if (!php_handler_->initialize()) {
                 std::cerr << "I failed to initialize PHP handler" << std::endl;


### PR DESCRIPTION
## Summary
- rename php_fmp identifiers and options to php_fpm across build scripts and source
- update function names and configuration handling for PHP-FPM
- ensure server and config parser reference new php_fpm struct member

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689569156328832b89aa042f07b029de