### PR TITLE
fix: use tab for dev-reset configure command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,7 +140,7 @@ dev-reset: bootstrap-clean
 	./autogen.sh
 	@echo "Configuring with development options..."
 
-        ./configure --enable-debug --enable-ssl --enable-php-fpm
+	./configure --enable-debug --enable-ssl --enable-php-fpm
 	@echo "Development environment reset complete."
 
 # I'm adding a help target that explains all the cleaning options


### PR DESCRIPTION
## Summary
- replace spaces with a tab before the configure command in the dev-reset recipe so `make` recognizes it properly

## Testing
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6895705d7cac832b9d66ed0db600a435