### PR TITLE
refactor: update PHP handler initialization

### DIFF
--- a/include/php_handler.h
+++ b/include/php_handler.h
@@ -95,6 +95,27 @@ struct PHPHandlerStats {
     uint64_t peak_response_time_ms{0};
     std::atomic<uint64_t> active_connections{0};
     std::chrono::steady_clock::time_point last_error_time;
+
+    PHPHandlerStats() = default;
+    PHPHandlerStats(const PHPHandlerStats& other)
+        : total_requests(other.total_requests.load())
+        , successful_requests(other.successful_requests.load())
+        , failed_requests(other.failed_requests.load())
+        , average_response_time_ms(other.average_response_time_ms)
+        , peak_response_time_ms(other.peak_response_time_ms)
+        , active_connections(other.active_connections.load())
+        , last_error_time(other.last_error_time) {}
+
+    PHPHandlerStats& operator=(const PHPHandlerStats& other) {
+        total_requests.store(other.total_requests.load());
+        successful_requests.store(other.successful_requests.load());
+        failed_requests.store(other.failed_requests.load());
+        average_response_time_ms = other.average_response_time_ms;
+        peak_response_time_ms = other.peak_response_time_ms;
+        active_connections.store(other.active_connections.load());
+        last_error_time = other.last_error_time;
+        return *this;
+    }
 };
 
 class PHPHandler {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -183,21 +183,17 @@ bool ICY2Server::initialize(const std::string& config_path) {
             }
         }
 
-        // I create and configure the PHP handler if enabled
+        // I create and initialize the PHP handler if enabled
         if (server_config.php_fpm.enabled) {
-            php_handler_ = std::make_unique<PHPHandler>();
+            php_handler_ = std::make_unique<PHPHandler>(
+                server_config.php_fpm.socket_path,
+                server_config.php_fpm.document_root,
+                server_config.php_fpm);
 
-            if (!php_handler_->configure(server_config.php_fpm)) {
+            if (!php_handler_->initialize()) {
                 std::cerr << "I failed to initialize PHP handler" << std::endl;
                 return false;
             }
-
-            // I add a default PHP-FPM pool using the parsed PHP configuration
-            if (!php_handler_->add_pool("default", server_config.php_fpm)) {
-                std::cerr << "I failed to add PHP-FPM pool" << std::endl;
-                return false;
-            }
-
         }
 
         std::cout << "I successfully initialized ICY2Server" << std::endl;


### PR DESCRIPTION
## Summary
- construct PHP handler with socket and document root from configuration
- add copy operations to PHPHandlerStats to allow returning statistics

## Testing
- `./autogen.sh` *(fails: aclocal missing -> installed automake, autoconf-archive, libtool)*
- `./configure`
- `make -j$(nproc)` *(fails: helper.cpp: LogLevel not declared)*


------
https://chatgpt.com/codex/tasks/task_e_689577c7d964832b937dc9787f43a733