### PR TITLE
Include common_types.h in helper header

### DIFF
--- a/include/helper.h
+++ b/include/helper.h
@@ -43,6 +43,8 @@
 #include <sstream>
 #include <iostream>
 
+#include "common_types.h"
+
 // I'm including system headers for Linux functionality
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
## Summary
- include `common_types.h` in `helper.h` so `LogLevel` enum is available

## Testing
- `g++ -std=c++17 -Iinclude /tmp/test.cpp -c -o /tmp/test.o`

------
https://chatgpt.com/codex/tasks/task_e_68958170c534832baf788bcf880b00fc