### PR TITLE
refactor: rename directory flag and fix call

### DIFF
--- a/include/helper.h
+++ b/include/helper.h
@@ -305,7 +305,7 @@ public:
      * I'm creating the file writing method
      * This safely writes file contents
      */
-    bool write_file_contents(const std::string& file_path, const std::string& contents, bool create_directories = false);
+    bool write_file_contents(const std::string& file_path, const std::string& contents, bool create_dirs = false);
 
     /**
      * I'm creating the file modification time method

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -591,12 +591,12 @@ std::string APIHelper::read_file_contents(const std::string& file_path, size_t m
  * This safely writes file contents
  */
 bool APIHelper::write_file_contents(const std::string& file_path, const std::string& contents,
-                                   bool create_directories) {
-    if (create_directories) {
+                                   bool create_dirs) {
+    if (create_dirs) {
         size_t last_slash = file_path.find_last_of('/');
         if (last_slash != std::string::npos) {
             std::string dir_path = file_path.substr(0, last_slash);
-            if (!create_directories(dir_path)) {
+            if (!this->create_directories(dir_path)) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- rename `write_file_contents` parameter to `create_dirs`
- use `this->create_directories` when creating directories for file writes

## Testing
- `g++ -std=c++17 -Iinclude -c src/helper.cpp -o /tmp/helper.o` *(fails: 'NetworkInfo' was not declared, etc., but 'cannot be used as a function' error is absent)*

------
https://chatgpt.com/codex/tasks/task_e_689584cdfd24832babc0c4a43ad0ad40