### PR TITLE
refactor: unify network interface struct usage

### DIFF
--- a/include/helper.h
+++ b/include/helper.h
@@ -456,9 +456,10 @@ private:
     /**
      * I'm creating internal utility methods
      * These provide implementation details for public methods
-     */
+    */
     std::string get_distribution_info();
     std::vector<double> get_load_averages();
+    std::vector<NetworkInterface> gather_network_info();
     std::string format_timestamp(const std::chrono::system_clock::time_point& time_point);
 };
 


### PR DESCRIPTION
## Summary
- replace deprecated `NetworkInfo` with `NetworkInterface` throughout helper code
- declare private `gather_network_info` helper in header
- include `<net/if.h>` and streamline field usage to match struct

## Testing
- `g++ -std=c++17 -Iinclude -c src/helper.cpp -o /tmp/helper.o`


------
https://chatgpt.com/codex/tasks/task_e_689586197d90832b934673fca4c1ebb8